### PR TITLE
Update pdf generator, set executablePath of chrome dynamicly based on OS

### DIFF
--- a/pdf_generator.js
+++ b/pdf_generator.js
@@ -1,6 +1,7 @@
 const puppeteer = require('puppeteer-core');
 const fs = require('fs');
 const path = require('path');
+const os = require('os');
 
 const generatePDF = async () => {
 
@@ -8,7 +9,7 @@ const generatePDF = async () => {
 
 	const browser = await puppeteer.launch({
 		headless: true,
-		executablePath: '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+		executablePath: getChromeExecutablePath(),
 		args: ['--no-sandbox', '--disable-setuid-sandbox']
 	});
 
@@ -44,6 +45,26 @@ const generatePDF = async () => {
 			console.log(err);
 		}
 	});
+}
+
+const getChromeExecutablePath = () => {
+
+	const platform = os.platform();
+
+	if (platform === 'linux') {
+		return '/usr/bin/google-chrome';
+
+	} else if (platform === 'darwin') {
+		return '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+
+	} else if (platform === 'win32') {
+		return 'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe';
+
+	} else {
+		throw new Error('Unsupported platform: ' + platform);
+
+	}
+
 }
 
 generatePDF();


### PR DESCRIPTION
Changes were made to detect the path of the Chrome browser executable depending on the operating system on which the script is running. Thus, the script can use this path in the program and create a PDF file without any issues across different operating systems.
Currently, the operating systems Windows, macOS, and Linux are checked, and if the operating system is outside of these three, an error message will be displayed during execution.